### PR TITLE
case statements

### DIFF
--- a/php-coding-standards.md
+++ b/php-coding-standards.md
@@ -147,25 +147,25 @@ Put spaces on both sides of the opening and closing parenthesis of `if`, `elseif
 foreach ( $foo as $bar ) { ...
 ```
 
-When using case statements, do it like so:
+When using `case` statements, do it like so:
 
 ```php
 
-switch ($i) {
+switch ( $i ) {
     case 1:
-        echo "i equals 1";
+        echo 'i equals 1';
         break;
     case 2:
-        echo "i equals 2";
+        echo 'i equals 2';
         break;
-    case 3 : // incorrect, do not include a space before the colon
-        echo "i equals 2";
+    case 3 : // Incorrect, do not include a space before the colon.
+        echo 'i equals 2';
         break;
-    case 4; // incorrect, use colons not semicolons
-        echo "i equals 2";
+    case 4; // Incorrect, use colons not semicolons.
+        echo 'i equals 2';
         break;
     default:
-       echo "i is not equal to 0, 1 or 2";
+       echo 'i is not equal to 0, 1 or 2';
 }
 
 ```

--- a/php-coding-standards.md
+++ b/php-coding-standards.md
@@ -150,22 +150,21 @@ foreach ( $foo as $bar ) { ...
 When using `case` statements, do it like so:
 
 ```php
-
 switch ( $i ) {
     case 1:
-        echo 'i equals 1';
+        echo '$i equals 1';
         break;
     case 2:
-        echo 'i equals 2';
+        echo '$i equals 2';
         break;
     case 3 : // Incorrect, do not include a space before the colon.
-        echo 'i equals 2';
+        echo '$i equals 2';
         break;
     case 4; // Incorrect, use colons not semicolons.
-        echo 'i equals 2';
+        echo '$i equals 2';
         break;
     default:
-       echo 'i is not equal to 0, 1 or 2';
+       echo '$i is not equal to 0, 1 or 2';
 }
 
 ```

--- a/php-coding-standards.md
+++ b/php-coding-standards.md
@@ -166,7 +166,6 @@ switch ( $i ) {
     default:
        echo '$i is not equal to 0, 1 or 2';
 }
-
 ```
 
 When defining a function, do it like so:

--- a/php-coding-standards.md
+++ b/php-coding-standards.md
@@ -147,6 +147,29 @@ Put spaces on both sides of the opening and closing parenthesis of `if`, `elseif
 foreach ( $foo as $bar ) { ...
 ```
 
+When using case statements, do it like so:
+
+```php
+
+switch ($i) {
+    case 1:
+        echo "i equals 1";
+        break;
+    case 2:
+        echo "i equals 2";
+        break;
+    case 3 : // incorrect, do not include a space before the colon
+        echo "i equals 2";
+        break;
+    case 4; // incorrect, use colons not semicolons
+        echo "i equals 2";
+        break;
+    default:
+       echo "i is not equal to 0, 1 or 2";
+}
+
+```
+
 When defining a function, do it like so:
 
 ```php


### PR DESCRIPTION
Some stats:

`case string :`- (space before colon)
```shell
ag "case\s[\'\w\']+\s\:" --stats-only
299 matches
47 files contained matches
1767 files searched
```


`case string:`- (no space before colon)
```shell
ag "case\s[\'\w\']+\:" --stats-only
2637 matches
148 files contained matches
1767 files searched
```

`case string ;`-  (space before semicolon)
```shell
ag "case\s[\'\w\']+\s\;" --stats-only
0 matches
0 files contained matches
1767 files searched
```

`case string ;`- (no space before semicolon)
```shell
ag "case\s[\'\w\']+\;" --stats-only
2 matches
2 files contained matches
1767 files searched
```